### PR TITLE
Add ability to guess by episode number

### DIFF
--- a/indexold.html
+++ b/indexold.html
@@ -65,7 +65,7 @@
 <body>
 <div id="image-container"></div>
 <div id="filename"></div>
-<input id="guess-input" list="episode-names" placeholder="Guess the episode..." onkeypress="handleKeyPress(event)">
+<input id="guess-input" list="episode-names" placeholder="Guess the episode (name or number)..." onkeypress="handleKeyPress(event)">
 <button id="guess-button" onclick="checkGuess(document.getElementById('guess-input').value)">Guess</button>
 <button id="try-again-button" onclick="resetGame()">Try Again</button>
 <datalist id="episode-names">
@@ -122,8 +122,20 @@
         }
     }
 
+    function getGuessValue(guess) {
+      if (Object.keys(episodes).includes(guess)) return guess;
+      
+      const guessAsIndex = parseInt(guess);
+      if (1 <= guessAsIndex && guessAsIndex <= Object.keys(episodes).length) {
+        return Object.keys(episodes)[guessAsIndex - 1];
+      }
+      
+      return undefined;
+    }
+    
     function checkGuess(guess) {
-        if (Object.keys(episodes).includes(guess)) {
+        guess = getGuessValue(guess);
+        if (guess !== undefined) {
             if (guess === currentEpisode) {
                 score++;
                 showRandomImage();


### PR DESCRIPTION
If a user submits a number between 1 and the episode count it will be treated as a valid guess of the episode of that number.
This was missing for me to properly play on my phone, since Firefox on Android doesn't support datalists.

I noticed that I had to make the changes to `oldindex.html`,  since `index.html` now redirects to http://episod.io. Is there a different place I need to submit this PR to for it to be deployed at http://episod.io?